### PR TITLE
gralloc: Fix RAW10/12 buffer alignment for trinket

### DIFF
--- a/gralloc/Android.mk
+++ b/gralloc/Android.mk
@@ -53,6 +53,10 @@ ifeq ($(TARGET_USES_UNALIGNED_YCRCB),true)
     LOCAL_CFLAGS              += -DUSE_UNALIGNED_YCRCB
 endif
 
+ifeq ($(TARGET_NEEDS_RAW10_BUFFER_FIX),true)
+LOCAL_CFLAGS                  += -DRAW10_BUFFER_FIX
+endif
+
 LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps)
 LOCAL_SRC_FILES               := gr_utils.cpp gr_adreno_info.cpp
 include $(BUILD_SHARED_LIBRARY)

--- a/gralloc/gr_utils.cpp
+++ b/gralloc/gr_utils.cpp
@@ -1020,10 +1020,18 @@ void GetAlignedWidthAndHeight(const BufferInfo &info, unsigned int *alignedw,
       aligned_w = ALIGN(width, 16);
       break;
     case HAL_PIXEL_FORMAT_RAW12:
+#ifdef RAW10_BUFFER_FIX
+      aligned_w = ALIGN(width * 12 / 8, 8);
+#else
       aligned_w = ALIGN(width * 12 / 8, 16);
+#endif
       break;
     case HAL_PIXEL_FORMAT_RAW10:
+#ifdef RAW10_BUFFER_FIX
+      aligned_w = ALIGN(width * 10 / 8, 8);
+#else
       aligned_w = ALIGN(width * 10 / 8, 16);
+#endif
       break;
     case HAL_PIXEL_FORMAT_RAW8:
       aligned_w = ALIGN(width, 16);


### PR DESCRIPTION
[Vishalcj17] Guard with TARGET_NEEDS_RAW10_BUFFER_FIX
Signed-off-by: Vishalcj17 <vishalcj@aospa.co>
Change-Id: Ic70b21180d7c8441bf794a08405fe4428a42d8ec