### PR TITLE
gralloc: Allow devices to opt-in for YCrCb camera video encode

### DIFF
--- a/gralloc/Android.bp
+++ b/gralloc/Android.bp
@@ -29,6 +29,9 @@ cc_library_shared {
     }) + select(soong_config_variable("qtidisplay", "target_uses_unaligned_ycrcb"), {
         "true": ["-DUSE_UNALIGNED_YCRCB"],
         default: [],
+    }) + select(soong_config_variable("qtidisplay", "target_uses_ycrcb_camera_encode"), {
+        "true": ["-DUSE_YCRCB_CAMERA_ENCODE"],
+        default: [],
     }) + select(soong_config_variable("qtidisplay", "target_uses_ycrcb_camera_preview"), {
         "true": ["-DUSE_YCRCB_CAMERA_PREVIEW"],
         default: [],

--- a/gralloc/gr_utils.cpp
+++ b/gralloc/gr_utils.cpp
@@ -1369,7 +1369,15 @@ int GetImplDefinedFormat(uint64_t usage, int format) {
       } else if (usage & GRALLOC_USAGE_PRIVATE_HEIF) {
         gr_format = HAL_PIXEL_FORMAT_NV12_HEIF;
       } else if (format == HAL_PIXEL_FORMAT_YCbCr_420_888) {
+#ifdef USE_YCRCB_CAMERA_ENCODE
+        if (usage & BufferUsage::CAMERA_OUTPUT) {
+          gr_format = HAL_PIXEL_FORMAT_YCrCb_420_SP_VENUS;
+        } else {
+          gr_format = HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS;
+        }
+#else
         gr_format = HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS;
+#endif
       } else {
         gr_format = HAL_PIXEL_FORMAT_NV12_ENCODEABLE;  // NV12
       }


### PR DESCRIPTION
DeviceAsWebcam is using USAGE_VIDEO_ENCODE [1] for buffers and this results in combined usage: (VIDEO_ENCODER | CAMERA_OUTPUT).

On some Qcom devices (verified on pyxis (sdm710)) and maybe others DeviceAsWebcam has red & blue colors swapped with HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS.

When using HAL_PIXEL_FORMAT_YCrCb_420_SP_VENUS the output from DeviceAsWebcam has correct colors.

[1] https://android.googlesource.com/platform/packages/services/DeviceAsWebcam/+/d079a82ba4f773210c01d488d2dfa1d4d25be8e2

Change-Id: I4376102e2b0eeaefed536eff29c315a71e469b57